### PR TITLE
Stream files to the client, rather than forcing them to be loaded into memory

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -444,10 +444,11 @@ func (cmd commandRetr) RequireAuth() bool {
 
 func (cmd commandRetr) Execute(conn *ftpConn, param string) {
 	path := conn.buildPath(param)
-	data, err := conn.driver.GetFile(path)
+	reader, err := conn.driver.GetFile(path)
 	if err == nil {
-		conn.writeMessage(150, fmt.Sprintf("Data transfer starting %d bytes", len(data)))
-		conn.sendOutofbandData(data)
+		defer reader.Close()
+		conn.writeMessage(150, "Data connection open. Transfer starting.")
+		conn.sendOutofbandReader(reader)
 	} else {
 		conn.writeMessage(551, "File not available")
 	}

--- a/ftpdriver.go
+++ b/ftpdriver.go
@@ -58,8 +58,8 @@ type FTPDriver interface {
 	MakeDir(string) bool
 
 	// params  - path
-	// returns - a string containing the file data to send to the client
-	GetFile(string) (string, error)
+	// returns - a Reader that will return file data to send to the client
+	GetFile(string) (io.ReadCloser, error)
 
 	// params  - desination path, an io.Reader containing the file data
 	// returns - true if the data was successfully persisted

--- a/graval-mem/graval-mem.go
+++ b/graval-mem/graval-mem.go
@@ -16,8 +16,10 @@ package main
 import (
 	"github.com/yob/graval"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -79,12 +81,12 @@ func (driver *MemDriver) Rename(fromPath string, toPath string) bool {
 func (driver *MemDriver) MakeDir(path string) bool {
 	return false
 }
-func (driver *MemDriver) GetFile(path string) (data string, err error) {
+func (driver *MemDriver) GetFile(path string) (reader io.ReadCloser, err error) {
 	switch path {
 	case "/one.txt":
-		data = fileOne
+		reader = ioutil.NopCloser(strings.NewReader(fileOne))
 	case "/files/two.txt":
-		data = fileTwo
+		reader = ioutil.NopCloser(strings.NewReader(fileTwo))
 	}
 	return
 }


### PR DESCRIPTION
This is largely based on the existing work in a fork (https://github.com/koofr/graval).

If we change the driver contract for GetFile to return an io.ReadCloser, then the driver has the option to stream the file contents to the client. This should make it feasible to transfer much larger files.

Closes #6