### PR TITLE
Feature close

### DIFF
--- a/ftpserver.go
+++ b/ftpserver.go
@@ -178,6 +178,7 @@ func (ftpServer *FTPServer) ListenAndServe() error {
 	return nil
 }
 
+// Close signals the server to stop. It may take a couple of seconds. Do not call ListenAndServe again after this, build a new FTPServer.
 func (ftpServer *FTPServer) Close() {
 	select {
 	case <-ftpServer.closeChan:

--- a/ftpserver_test.go
+++ b/ftpserver_test.go
@@ -31,6 +31,31 @@ func TestClose(t *testing.T) {
 	})
 }
 
+func TestCloseLater(t *testing.T) {
+	t.Skip("Waits a while, which you don't need to")
+	goneChan := make(chan struct{})
+
+	Convey("Setting up a minimal server, it will end if Close() is called ", t, func() {
+		opts := &FTPServerOpts{
+			ServerName:  "blah blah blah",
+			PasvMinPort: 60200,
+			PasvMaxPort: 60300,
+		}
+		ftpServer := NewFTPServer(opts)
+		go func() {
+			defer close(goneChan)
+			err := ftpServer.ListenAndServe()
+			if err != nil {
+				panic(err)
+			}
+		}()
+		time.Sleep(10 * time.Second)
+		So(ftpServer.Close, ShouldNotPanic)
+		<-goneChan
+
+	})
+}
+
 func TestCloseHammer(t *testing.T) {
 
 	goneChan := make(chan struct{})

--- a/ftpserver_test.go
+++ b/ftpserver_test.go
@@ -1,0 +1,65 @@
+package graval
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+	"time"
+)
+
+func TestClose(t *testing.T) {
+
+	goneChan := make(chan struct{})
+
+	Convey("Setting up a minimal server, it will end if Close() is called ", t, func() {
+		opts := &FTPServerOpts{
+			ServerName:  "blah blah blah",
+			PasvMinPort: 60200,
+			PasvMaxPort: 60300,
+		}
+		ftpServer := NewFTPServer(opts)
+		go func() {
+			defer close(goneChan)
+			err := ftpServer.ListenAndServe()
+			if err != nil {
+				panic(err)
+			}
+		}()
+		time.Sleep(1 * time.Second)
+		So(ftpServer.Close, ShouldNotPanic)
+		<-goneChan
+
+	})
+}
+
+func TestCloseHammer(t *testing.T) {
+
+	goneChan := make(chan struct{})
+
+	Convey("Setting up a minimal server, it will end if Close() is called a bunch of times", t, func() {
+		opts := &FTPServerOpts{
+			ServerName:  "blah blah blah",
+			PasvMinPort: 60200,
+			PasvMaxPort: 60300,
+		}
+		ftpServer := NewFTPServer(opts)
+		go func() {
+			defer close(goneChan)
+			err := ftpServer.ListenAndServe()
+			if err != nil {
+				panic(err)
+			}
+		}()
+		time.Sleep(1 * time.Second)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+		So(ftpServer.Close, ShouldNotPanic)
+
+		<-goneChan
+
+	})
+}


### PR DESCRIPTION
Hi :) I needed to close this puppy down ( as did #14 ) and tried to stay as minimally invasive as possible. Using a ``select{}`` inside the ``for{}``, and a 2 second deadline before the ``Accept()``, allows for reliable closure of the listener. The closure is terminal, and an entire new FtpServer needs to be rolled up if it's to be used thereafter.
